### PR TITLE
fix: crash in build during release due to missing plugins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build api-client
-        run: pnpm --filter @edufeed-org/oer-finder-api-client run build
+      - name: Build dependencies
+        run: |
+          pnpm --filter @edufeed-org/oer-adapter-core run build
+          pnpm --filter @edufeed-org/oer-adapter-openverse run build
+          pnpm --filter @edufeed-org/oer-adapter-rpi-virtuell run build
+          pnpm --filter @edufeed-org/oer-adapter-arasaac run build
+          pnpm --filter @edufeed-org/oer-adapter-nostr-amb-relay run build
+          pnpm --filter @edufeed-org/oer-finder-api-client run build
 
       - name: Build oer-finder-plugin
         run: pnpm --filter @edufeed-org/oer-finder-plugin run build


### PR DESCRIPTION
The plugin builds were missing in the release of the npm packages as these are now required for the local version.