### PR TITLE
refactor: convert selected to checked 

### DIFF
--- a/docs/client-packages-angular.md
+++ b/docs/client-packages-angular.md
@@ -139,9 +139,9 @@ Set the `sources` property in `ngAfterViewInit` as shown in the example above.
 import type { SourceConfig } from '@edufeed-org/oer-finder-plugin';
 
 // Server-proxy mode sources (with api-url set)
-// Use selected: true to set the default source
+// Use checked: true to set the pre-selected sources
 const serverSources: SourceConfig[] = [
-  { id: 'nostr-amb-relay', label: 'AMB Relay', selected: true },
+  { id: 'nostr-amb-relay', label: 'AMB Relay', checked: true },
   { id: 'openverse', label: 'Openverse' },
   { id: 'arasaac', label: 'ARASAAC' },
 ];
@@ -149,7 +149,7 @@ const serverSources: SourceConfig[] = [
 // Direct client mode sources (without api-url)
 const directSources: SourceConfig[] = [
   { id: 'openverse', label: 'Openverse' },
-  { id: 'arasaac', label: 'ARASAAC', selected: true },
+  { id: 'arasaac', label: 'ARASAAC', checked: true },
   { id: 'nostr-amb-relay', label: 'Nostr AMB Relay', baseUrl: 'wss://amb-relay.edufeed.org' },
 ];
 ```

--- a/docs/client-packages-react.md
+++ b/docs/client-packages-react.md
@@ -29,9 +29,9 @@ import {
   type SourceConfig,
 } from '@edufeed-org/oer-finder-plugin-react';
 
-// Configure available sources (selected: true sets the default)
+// Configure available sources (checked: true sets the pre-selected sources)
 const SOURCES: SourceConfig[] = [
-  { id: 'nostr', label: 'Nostr', selected: true },
+  { id: 'nostr', label: 'Nostr', checked: true },
   { id: 'openverse', label: 'Openverse' },
   { id: 'arasaac', label: 'ARASAAC' },
 ];

--- a/docs/client-packages-svelte.md
+++ b/docs/client-packages-svelte.md
@@ -114,9 +114,9 @@ For **server-proxy mode** (with `api-url`):
 <script lang="ts">
   import type { SourceConfig } from '@edufeed-org/oer-finder-plugin';
 
-  // Use selected: true to set the default source
+  // Use checked: true to set the pre-selected sources
   const sources: SourceConfig[] = [
-    { id: 'nostr-amb-relay', label: 'AMB Relay', selected: true },
+    { id: 'nostr-amb-relay', label: 'AMB Relay', checked: true },
     { id: 'openverse', label: 'Openverse' },
     { id: 'arasaac', label: 'ARASAAC' },
   ];
@@ -131,7 +131,7 @@ For **direct client mode** (without `api-url`), provide `baseUrl` where needed:
 
   const sources: SourceConfig[] = [
     { id: 'openverse', label: 'Openverse' },
-    { id: 'arasaac', label: 'ARASAAC', selected: true },
+    { id: 'arasaac', label: 'ARASAAC', checked: true },
     { id: 'nostr-amb-relay', label: 'Nostr AMB Relay', baseUrl: 'wss://amb-relay.edufeed.org' },
   ];
 </script>

--- a/docs/client-packages.md
+++ b/docs/client-packages.md
@@ -430,8 +430,8 @@ interface SourceConfig {
   readonly label: string;
   /** Base URL for the source adapter (e.g., relay URL, API endpoint) */
   readonly baseUrl?: string;
-  /** Mark this source as the default selection. First marked source wins. */
-  readonly selected?: boolean;
+  /** Mark this source as pre-checked in the UI. Only checked sources are selected by default. */
+  readonly checked?: boolean;
 }
 ```
 
@@ -446,7 +446,7 @@ interface SourceConfig {
 
 If no `sources` are provided, the plugin defaults to `openverse` and `arasaac`.
 
-**Default source selection:** By default, the first source in the array is selected. To override this, set `selected: true` on the source you want pre-selected. If multiple sources have `selected: true`, the first one wins.
+**Default source selection:** By default, all sources are pre-selected. To override this, set `checked: true` on the sources you want pre-selected. Only sources with `checked: true` will be initially checked. If no sources have `checked: true`, all are selected as a fallback.
 
 #### Setting Sources (Server-Proxy Mode)
 
@@ -454,7 +454,7 @@ If no `sources` are provided, the plugin defaults to `openverse` and `arasaac`.
 const searchElement = document.querySelector('oer-search');
 searchElement.sources = [
   { id: 'nostr-amb-relay', label: 'AMB Relay' },
-  { id: 'openverse', label: 'Openverse', selected: true },
+  { id: 'openverse', label: 'Openverse', checked: true },
   { id: 'arasaac', label: 'ARASAAC' },
 ];
 ```
@@ -465,7 +465,7 @@ searchElement.sources = [
 const searchElement = document.querySelector('oer-search');
 searchElement.sources = [
   { id: 'openverse', label: 'Openverse' },
-  { id: 'arasaac', label: 'ARASAAC', selected: true },
+  { id: 'arasaac', label: 'ARASAAC', checked: true },
   { id: 'nostr-amb-relay', label: 'Nostr AMB Relay', baseUrl: 'wss://amb-relay.edufeed.org' },
   { id: 'rpi-virtuell', label: 'RPI-Virtuell' },
 ];

--- a/packages/oer-finder-plugin-example/src/main.ts
+++ b/packages/oer-finder-plugin-example/src/main.ts
@@ -88,7 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const apiSearch = document.getElementById('oer-search-api') as OerSearchElement | null;
   if (apiSearch) {
     const serverSources: SourceConfig[] = [
-      { id: 'nostr-amb-relay', label: 'AMB Relay', selected: true },
+      { id: 'nostr-amb-relay', label: 'AMB Relay', checked: true },
       { id: 'openverse', label: 'Openverse' },
       { id: 'arasaac', label: 'ARASAAC' },
       { id: 'rpi-virtuell', label: 'RPI-Virtuell' },
@@ -102,7 +102,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (directSearch) {
     const directSources: SourceConfig[] = [
       { id: 'openverse', label: 'Openverse' },
-      { id: 'arasaac', label: 'ARASAAC', selected: true },
+      { id: 'arasaac', label: 'ARASAAC', checked: true },
       { id: 'nostr-amb-relay', label: 'Nostr AMB Relay', baseUrl: 'wss://amb-relay.edufeed.org' },
       { id: 'rpi-virtuell', label: 'RPI-Virtuell' },
     ];

--- a/packages/oer-finder-plugin-react-example/src/App.tsx
+++ b/packages/oer-finder-plugin-react-example/src/App.tsx
@@ -21,7 +21,7 @@ import {
 } from '@edufeed-org/oer-finder-plugin-react';
 
 const SERVER_SOURCES: SourceConfig[] = [
-  { id: 'nostr', label: 'Nostr', selected: true },
+  { id: 'nostr', label: 'Nostr', checked: true },
   { id: 'arasaac', label: 'ARASAAC' },
 ];
 

--- a/packages/oer-finder-plugin/src/adapters/adapter-manager.test.ts
+++ b/packages/oer-finder-plugin/src/adapters/adapter-manager.test.ts
@@ -84,32 +84,32 @@ describe('AdapterManager', () => {
     expect(manager.getDefaultSourceId()).toBe('openverse');
   });
 
-  it('returns selected source as default when selected flag is set', () => {
+  it('returns checked source as default when checked flag is set', () => {
     const configs: SourceConfig[] = [
       { id: 'openverse', label: 'OV' },
-      { id: 'arasaac', label: 'AR', selected: true },
+      { id: 'arasaac', label: 'AR', checked: true },
     ];
     const manager = AdapterManager.fromSourceConfigs(configs);
 
     expect(manager.getDefaultSourceId()).toBe('arasaac');
   });
 
-  it('includes selected flag in available sources', () => {
+  it('includes checked flag in available sources', () => {
     const configs: SourceConfig[] = [
       { id: 'openverse', label: 'OV' },
-      { id: 'arasaac', label: 'AR', selected: true },
+      { id: 'arasaac', label: 'AR', checked: true },
     ];
     const manager = AdapterManager.fromSourceConfigs(configs);
 
     expect(manager.getAvailableSources()).toEqual([
       { id: 'openverse', label: 'OV' },
-      { id: 'arasaac', label: 'AR', selected: true },
+      { id: 'arasaac', label: 'AR', checked: true },
     ]);
   });
 
-  it('ignores selected on unknown or skipped adapter IDs', () => {
+  it('ignores checked on unknown or skipped adapter IDs', () => {
     const configs: SourceConfig[] = [
-      { id: 'nostr', label: 'Nostr DB', selected: true },
+      { id: 'nostr', label: 'Nostr DB', checked: true },
       { id: 'openverse', label: 'OV' },
     ];
     const manager = AdapterManager.fromSourceConfigs(configs);
@@ -135,15 +135,30 @@ describe('AdapterManager', () => {
     expect(sources).toEqual([{ id: 'openverse', label: 'OV' }]);
   });
 
-  it('uses first selected source when multiple are marked', () => {
+  it('uses first checked source when multiple are marked', () => {
     const configs: SourceConfig[] = [
       { id: 'openverse', label: 'OV' },
-      { id: 'arasaac', label: 'AR', selected: true },
-      { id: 'rpi-virtuell', label: 'RPI', selected: true },
+      { id: 'arasaac', label: 'AR', checked: true },
+      { id: 'rpi-virtuell', label: 'RPI', checked: true },
     ];
     const manager = AdapterManager.fromSourceConfigs(configs);
 
     expect(manager.getDefaultSourceId()).toBe('arasaac');
+  });
+
+  it('includes checked flag on all checked sources in available sources', () => {
+    const configs: SourceConfig[] = [
+      { id: 'openverse', label: 'OV' },
+      { id: 'arasaac', label: 'AR', checked: true },
+      { id: 'rpi-virtuell', label: 'RPI', checked: true },
+    ];
+    const manager = AdapterManager.fromSourceConfigs(configs);
+
+    expect(manager.getAvailableSources()).toEqual([
+      { id: 'openverse', label: 'OV' },
+      { id: 'arasaac', label: 'AR', checked: true },
+      { id: 'rpi-virtuell', label: 'RPI', checked: true },
+    ]);
   });
 
   describe('filter guard in search', () => {

--- a/packages/oer-finder-plugin/src/clients/api-client.test.ts
+++ b/packages/oer-finder-plugin/src/clients/api-client.test.ts
@@ -163,16 +163,16 @@ describe('ApiClient', () => {
   });
 
   describe('getDefaultSourceId', () => {
-    it('returns selected source as default', () => {
+    it('returns checked source as default', () => {
       const client = new ApiClient('https://api.example.com', [
         { id: 'nostr', label: 'Nostr' },
-        { id: 'openverse', label: 'OV', selected: true },
+        { id: 'openverse', label: 'OV', checked: true },
       ]);
 
       expect(client.getDefaultSourceId()).toBe('openverse');
     });
 
-    it('falls back to first source when none selected', () => {
+    it('falls back to first source when none checked', () => {
       const client = new ApiClient('https://api.example.com', sources);
 
       expect(client.getDefaultSourceId()).toBe('nostr');

--- a/packages/oer-finder-plugin/src/clients/api-client.ts
+++ b/packages/oer-finder-plugin/src/clients/api-client.ts
@@ -54,10 +54,10 @@ export class ApiClient implements SearchClient {
 
   /**
    * Get the default source ID.
-   * Prefers the first source marked with selected: true; falls back to sources[0].
+   * Prefers the first source marked with checked: true; falls back to sources[0].
    */
   getDefaultSourceId(): string {
-    return this.sources.find((s) => s.selected === true)?.id ?? this.sources[0]?.id ?? 'openverse';
+    return this.sources.find((s) => s.checked === true)?.id ?? this.sources[0]?.id ?? 'openverse';
   }
 
   /**

--- a/packages/oer-finder-plugin/src/clients/client-factory.test.ts
+++ b/packages/oer-finder-plugin/src/clients/client-factory.test.ts
@@ -48,20 +48,20 @@ describe('ClientFactory', () => {
     ]);
   });
 
-  it('propagates selected flag to ApiClient source options', () => {
+  it('propagates checked flag to ApiClient source options', () => {
     const sources: SourceConfig[] = [
       { id: 'nostr', label: 'Nostr DB' },
-      { id: 'openverse', label: 'OV', selected: true },
+      { id: 'openverse', label: 'OV', checked: true },
     ];
     const client = ClientFactory.create({ apiUrl: 'https://api.example.com', sources });
 
     expect(client.getAvailableSources()).toEqual([
       { id: 'nostr', label: 'Nostr DB' },
-      { id: 'openverse', label: 'OV', selected: true },
+      { id: 'openverse', label: 'OV', checked: true },
     ]);
   });
 
-  it('uses first source as default when no selected flag in ApiClient', () => {
+  it('uses first source as default when no checked flag in ApiClient', () => {
     const sources: SourceConfig[] = [
       { id: 'nostr', label: 'Nostr DB' },
       { id: 'openverse', label: 'OV' },
@@ -71,10 +71,10 @@ describe('ClientFactory', () => {
     expect(client.getDefaultSourceId()).toBe('nostr');
   });
 
-  it('returns selected source as default in ApiClient', () => {
+  it('returns checked source as default in ApiClient', () => {
     const sources: SourceConfig[] = [
       { id: 'nostr', label: 'Nostr DB' },
-      { id: 'openverse', label: 'OV', selected: true },
+      { id: 'openverse', label: 'OV', checked: true },
     ];
     const client = ClientFactory.createApiClient('https://api.example.com', sources);
 

--- a/packages/oer-finder-plugin/src/clients/client-factory.ts
+++ b/packages/oer-finder-plugin/src/clients/client-factory.ts
@@ -43,7 +43,7 @@ export class ClientFactory {
       const sourceOptions = sources.map((s) => ({
         id: s.id,
         label: s.label,
-        ...(s.selected === true && { selected: true }),
+        ...(s.checked === true && { checked: true }),
       }));
       return ClientFactory.createApiClient(config.apiUrl, sourceOptions);
     }

--- a/packages/oer-finder-plugin/src/clients/direct-client.test.ts
+++ b/packages/oer-finder-plugin/src/clients/direct-client.test.ts
@@ -35,10 +35,10 @@ describe('DirectClient', () => {
     });
   });
 
-  it('returns selected source ID as default when selected flag is set', () => {
+  it('returns checked source ID as default when checked flag is set', () => {
     const sources: SourceConfig[] = [
       { id: 'openverse', label: 'OV' },
-      { id: 'arasaac', label: 'AR', selected: true },
+      { id: 'arasaac', label: 'AR', checked: true },
     ];
     const client = new DirectClient(sources);
 

--- a/packages/oer-finder-plugin/src/clients/direct-client.ts
+++ b/packages/oer-finder-plugin/src/clients/direct-client.ts
@@ -63,7 +63,7 @@ export class DirectClient implements SearchClient {
 
   /**
    * Get the default source ID.
-   * Delegates to AdapterManager which prefers selected sources.
+   * Delegates to AdapterManager which prefers checked sources.
    */
   getDefaultSourceId(): string {
     return this.adapterManager.getDefaultSourceId();

--- a/packages/oer-finder-plugin/src/oer-search/OerSearch.ts
+++ b/packages/oer-finder-plugin/src/oer-search/OerSearch.ts
@@ -31,7 +31,7 @@ export interface SearchParams {
 export interface SourceOption {
   id: string;
   label: string;
-  selected?: boolean;
+  checked?: boolean;
 }
 
 export interface OerSearchResultEvent {
@@ -151,11 +151,11 @@ export class OerSearchElement extends LitElement {
 
     this.availableSources = this.client.getAvailableSources();
 
-    // Initialize selected sources: all checked by default, or locked to a single source
+    // Initialize selected sources: respect checked flags, or locked to a single source
     if (this.lockedSource && this.availableSources.some((s) => s.id === this.lockedSource)) {
       this.selectedSources = [this.lockedSource];
     } else {
-      this.selectedSources = this.availableSources.map((s) => s.id);
+      this.selectedSources = this.getDefaultSelectedSources();
     }
   }
 
@@ -214,7 +214,7 @@ export class OerSearchElement extends LitElement {
     if (this.lockedSource && this.availableSources.some((s) => s.id === this.lockedSource)) {
       this.selectedSources = [this.lockedSource];
     } else {
-      this.selectedSources = this.availableSources.map((s) => s.id);
+      this.selectedSources = this.getDefaultSelectedSources();
     }
   }
 
@@ -367,7 +367,7 @@ export class OerSearchElement extends LitElement {
     this.paginationController.reset();
     this.selectedSources = this.lockedSource
       ? [this.lockedSource]
-      : this.availableSources.map((s) => s.id);
+      : this.getDefaultSelectedSources();
     this.searchParams = {
       page: 1,
       pageSize: this.pageSize,
@@ -387,6 +387,17 @@ export class OerSearchElement extends LitElement {
         this.searchParams = { ...this.searchParams, [field]: value };
       }
     };
+  }
+
+  /**
+   * Determine which sources should be selected by default.
+   * If any sources have checked=true, select only those.
+   * If no sources have checked=true, select all (backward-compatible fallback).
+   */
+  private getDefaultSelectedSources(): string[] {
+    const checkedSources = this.availableSources.filter((s) => s.checked === true).map((s) => s.id);
+
+    return checkedSources.length > 0 ? checkedSources : this.availableSources.map((s) => s.id);
   }
 
   private handleSourceToggle(sourceId: string) {

--- a/packages/oer-finder-plugin/src/types/source-config.ts
+++ b/packages/oer-finder-plugin/src/types/source-config.ts
@@ -12,6 +12,6 @@ export interface SourceConfig {
   readonly label: string;
   /** Base URL for the source adapter (e.g., relay URL, API endpoint) */
   readonly baseUrl?: string;
-  /** Mark this source as the default selection. First marked source wins. */
-  readonly selected?: boolean;
+  /** Mark this source as pre-checked in the UI. Only checked sources are selected by default. First checked source is also used as the default source ID. */
+  readonly checked?: boolean;
 }


### PR DESCRIPTION
After the recent change to checkboxes for sources, the pre-selection does not work anymore and needs to be converted to checked logic.